### PR TITLE
Tests/mock router

### DIFF
--- a/ramlapi_test.go
+++ b/ramlapi_test.go
@@ -1,6 +1,8 @@
 package ramlapi
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -20,6 +22,37 @@ var handlers = map[string]http.HandlerFunc{
 }
 
 var router = mux.NewRouter().StrictSlash(true)
+var routerMock RouterMock
+
+type RouterMock struct {
+	routes map[string]map[string]string
+}
+
+func (router *RouterMock) Consume(data map[string]string) {
+	router.routes = make(map[string]map[string]string)
+	router.routes[data["path"]] = map[string]string{
+		data["verb"]: data["handler"],
+	}
+}
+
+func (router *RouterMock) String() {
+	for route, data := range router.routes {
+		fmt.Println(route)
+		for k, v := range data {
+			fmt.Println(k, v)
+		}
+	}
+}
+
+func (router *RouterMock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.String()
+	if _, found := router.routes[path]; found {
+		if _, found := router.routes[path][r.Method]; found {
+			handler := handlers[(router.routes[path][r.Method])]
+			handler(w, r)
+		}
+	}
+}
 
 func routerFunc(data map[string]string) {
 	router.
@@ -28,31 +61,46 @@ func routerFunc(data map[string]string) {
 		Handler(handlers[data["handler"]])
 }
 
+func routerFuncMock(data map[string]string) {
+	routerMock.Consume(data)
+}
+
 func buildAPI() {
 	api, _ := ProcessRAML("fixtures/valid.raml")
 	Build(api, routerFunc)
 }
 
+func buildAPIMock() {
+	api, _ := ProcessRAML("fixtures/valid.raml")
+	Build(api, routerFuncMock)
+}
+
 func GetMe(w http.ResponseWriter, r *http.Request) {
+	log.Fatal("GETME")
 	w.Write([]byte("GetMe"))
 }
 func PostMe(w http.ResponseWriter, r *http.Request) {
+	log.Fatal("POSTME")
 	w.Write([]byte("PostMe"))
 }
 
 func PutMe(w http.ResponseWriter, r *http.Request) {
+	log.Fatal("PUTME")
 	w.Write([]byte("PutMe"))
 }
 
 func PatchMe(w http.ResponseWriter, r *http.Request) {
+	log.Fatal("PATCHME")
 	w.Write([]byte("PatchMe"))
 }
 
 func HeadMe(w http.ResponseWriter, r *http.Request) {
+	log.Fatal("HEADME")
 	w.Write([]byte("HeadMe"))
 }
 
 func DeleteMe(w http.ResponseWriter, r *http.Request) {
+	log.Fatal("DELETEME")
 	w.Write([]byte("DeleteMe"))
 }
 
@@ -97,6 +145,39 @@ func TestValidRamlGetAssignments(t *testing.T) {
 		// router interface i.e. the handlers have been assigned when the
 		// API was built.
 		router.ServeHTTP(res, req)
+
+		// Now make sure every handler returns with a 200 OK and the
+		// correct response body.
+		if res.Code != 200 {
+			t.Fatalf("Expected a 200 response from %s, got %d\n", name, res.Code)
+		}
+		if res.Body.String() != name {
+			t.Fatalf("Expected to get %s response from %s, got %s\n", name, name, res.Body.String())
+		}
+	}
+}
+
+func TestValidRamlGetAssignmentsMock(t *testing.T) {
+	routerMock = RouterMock{}
+	// Build the API and assign handlers.
+	buildAPIMock()
+	// Cycle through the map and dispatch the appropriate
+	// HTTP requests to each one.
+	for name := range handlers {
+
+		matcher := regexp.MustCompile("^(Get|Post|Put|Patch|Head|Delete)")
+		match := matcher.FindSubmatch([]byte(name))
+		req, err := http.NewRequest(strings.ToUpper(string(match[0])), "/testapi", nil)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res := httptest.NewRecorder()
+		// We need to send this to the mux to ensure we are testing the
+		// router interface i.e. the handlers have been assigned when the
+		// API was built.
+		routerMock.ServeHTTP(res, req)
 
 		// Now make sure every handler returns with a 200 OK and the
 		// correct response body.

--- a/ramlapi_test.go
+++ b/ramlapi_test.go
@@ -107,7 +107,7 @@ func TestValidRaml(t *testing.T) {
 	}
 }
 
-func TestValidRamlGetAssignmentsMock(t *testing.T) {
+func TestValidRamlGetAssignments(t *testing.T) {
 	router = RouterMock{}
 	// Build the API and assign handlers.
 	buildAPI()


### PR DESCRIPTION
This branch eliminates the test dependency on Gorilla by rolling our own (simplified) router. All the tests should confirm is that the correct data (path, verb, handler etc) are passed to the consuming code. I extended this to also confirming that they get wired up to handlers which are callable. Anything more than that is domain logic and the responsibility of the consuming code.
