### PR TITLE
Refactor and tighten up code

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ in the RAML file. The router can then hook the data up however it likes.
 
 ```go
 router = mux.NewRouter().StrictSlash(true)
-api, err := ramlapi.ProcessRAML(f)
+api, err := ramlapi.Process(f)
     if err != nil {
 		log.Fatal(err)
 	}

--- a/ramlapi.go
+++ b/ramlapi.go
@@ -20,7 +20,7 @@ func Build(api *raml.APIDefinition, fun func(data map[string]string)) {
 func Process(file string) (*raml.APIDefinition, error) {
 	routes, err := raml.ParseFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("Failed parsing RAML file: %s\n", err.Error())
+		return nil, fmt.Errorf("Failed parsing RAML file: %s\n", err)
 	}
 
 	return routes, nil
@@ -98,7 +98,7 @@ func processResource(parent, name string, res *raml.Resource, fun func(data map[
 		fun(data)
 	}
 
-	// Get all children.
+	// Process all nested resources.
 	for name, n := range res.Nested {
 		return processResource(path, name, n, fun)
 	}

--- a/ramlapi_test.go
+++ b/ramlapi_test.go
@@ -1,4 +1,4 @@
-package ramlapi
+package ramlapi_test
 
 import (
 	"log"
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-)
 
-var routeMap map[string]http.HandlerFunc
+	"github.com/EconomistDigitalSolutions/ramlapi"
+)
 
 var handlers = map[string]http.HandlerFunc{
 	"GetMe":    GetMe,
@@ -20,7 +20,11 @@ var handlers = map[string]http.HandlerFunc{
 	"DeleteMe": DeleteMe,
 }
 
+var matcher = regexp.MustCompile("^(Get|Post|Put|Patch|Head|Delete)")
+
 var router RouterMock
+
+var routeMap map[string]http.HandlerFunc
 
 type RouterMock struct {
 	routes [][]string
@@ -60,19 +64,19 @@ func routerFunc(data map[string]string) {
 }
 
 func buildAPI() {
-	api, _ := ProcessRAML("fixtures/valid.raml")
-	Build(api, routerFunc)
+	api, _ := ramlapi.Process("fixtures/valid.raml")
+	ramlapi.Build(api, routerFunc)
 }
 
 func buildAPIQueries() {
-	api, _ := ProcessRAML("fixtures/queries.raml")
-	Build(api, routerFunc)
+	api, _ := ramlapi.Process("fixtures/queries.raml")
+	ramlapi.Build(api, routerFunc)
 }
 
 func GetMe(w http.ResponseWriter, r *http.Request) {
-	//log.Fatal("GETME")
 	w.Write([]byte("GetMe"))
 }
+
 func PostMe(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("PostMe"))
 }
@@ -93,26 +97,22 @@ func DeleteMe(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("DeleteMe"))
 }
 
-func QueryMe(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("QueryMe"))
-}
-
 func TestMissingRaml(t *testing.T) {
-	_, err := ProcessRAML("fixtures/missing.raml")
+	_, err := ramlapi.Process("fixtures/missing.raml")
 	if err == nil {
 		t.Fatal("Expected error with missing RAML file")
 	}
 }
 
 func TestInvalidRaml(t *testing.T) {
-	_, err := ProcessRAML("fixtures/invalid.raml")
+	_, err := ramlapi.Process("fixtures/invalid.raml")
 	if err == nil {
 		t.Fatal("Expected error with invalid RAML file")
 	}
 }
 
 func TestValidRaml(t *testing.T) {
-	_, err := ProcessRAML("fixtures/valid.raml")
+	_, err := ramlapi.Process("fixtures/valid.raml")
 	if err != nil {
 		t.Fatalf("Expected good response with valid RAML file, got %v\n", err)
 	}
@@ -127,7 +127,6 @@ func TestValidRamlGetAssignments(t *testing.T) {
 	// HTTP requests to each one.
 	for name := range handlers {
 
-		matcher := regexp.MustCompile("^(Get|Post|Put|Patch|Head|Delete)")
 		match := matcher.FindSubmatch([]byte(name))
 		req, err := http.NewRequest(strings.ToUpper(string(match[0])), "/testapi", nil)
 

--- a/ramlgen/main.go
+++ b/ramlgen/main.go
@@ -23,7 +23,7 @@ func init() {
 
 func main() {
 	flag.Parse()
-	api, err := ramlapi.ProcessRAML(ramlFile)
+	api, err := ramlapi.Process(ramlFile)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func generateMap(parent, name string, resource *raml.Resource, e *template.Templ
 	}
 
 	// Get all children.
-	for nestname, nested := range resource.Nested {
-		generateMap(resourcepath, nestname, nested, e, f)
+	for nestname, n := range resource.Nested {
+		generateMap(resourcepath, nestname, n, e, f)
 	}
 }

--- a/ramlgen/ramlgen_test.go
+++ b/ramlgen/ramlgen_test.go
@@ -12,7 +12,7 @@ import (
 var output = "/%s/test_gen_%d"
 
 func TestGenerate(t *testing.T) {
-	api, _ := ramlapi.ProcessRAML("../fixtures/valid.raml")
+	api, _ := ramlapi.Process("../fixtures/valid.raml")
 	currentOutput := fmt.Sprintf(output, os.TempDir(), int32(time.Now().Unix()))
 	generate(api, currentOutput)
 	_, err := os.Open(currentOutput)


### PR DESCRIPTION
1. Slim down main code by collapsing `raml.Method` checks into a map and loop.
2. Re-order exported and unexported functions for readability.
3. Drop some redundant test code and import `ramlapi` package into the test.
4. Strip down variable names and let the context do the talking.
